### PR TITLE
fix one untranslatable string #4 #hacktoberfest

### DIFF
--- a/frontend/public/i18n/pl.json
+++ b/frontend/public/i18n/pl.json
@@ -46,5 +46,6 @@
   "There are no matches to bet": "Brak meczy do typowania",
   "Close": "Zamknij",
   "Bets will be settled on the result at the end of the regular game time which includes injury time but excludes official extra time and penalty shoot outs": "Typy będą rozstrzygane jako wynik na koniec regulaminowego czasu gry wliczając czas doliczony przez sędziego, ale bez uwzględniania dogrywek i dodatkowych rzutów karnych",
-  "Knock-out stage": "Faza pucharowa"
+  "Knock-out stage": "Faza pucharowa",
+  "You're not playing any game. Create a new one or ask your friends to join an existing game.": "Nie uczestniczysz w żadnej grze, utwórz nową lub poproś przyjaciół o zaproszenie do istniejącej rozgrywki"
 }

--- a/frontend/src/component/GameList/index.tsx
+++ b/frontend/src/component/GameList/index.tsx
@@ -85,8 +85,7 @@ export class GameList extends React.PureComponent<GameListProps, State> {
 			return (
 				<TableRow>
 					<TableCell colSpan={2}>
-						Nie uczestniczysz w żadnej grze, utwórz nową lub poproś przyjaciół o zaproszenie do istniejącej
-						rozgrywki
+						<Trans>You're not playing any game. Create a new one or ask your friends to join an existing game.</Trans>
 					</TableCell>
 				</TableRow>
 			);


### PR DESCRIPTION
Hi pal, here's a partial fix for #4 , i wasn't able to translate the remaining strings

- Rozgrywki
- Zestawy meczy

which are both located in `frontend/src/component/MainMenu.tsx`

#hacktoberfest